### PR TITLE
ci: stop supporting x64 macos binaries

### DIFF
--- a/Templates/lotus-miner.rb
+++ b/Templates/lotus-miner.rb
@@ -8,12 +8,14 @@ class LotusMiner < Formula
   depends_on "hwloc"
 
   on_macos do
-    url "${MINER_MACOS_URL}"
-    sha256 "${MINER_MACOS_SHA}"
+    on_arm do
+      url "${MINER_MACOS_URL}"
+      sha256 "${MINER_MACOS_SHA}"
 
-    def install
-      bin.install "lotus-miner"
-      bin.install "lotus-worker"
+      def install
+        bin.install "lotus-miner"
+        bin.install "lotus-worker"
+      end
     end
   end
 

--- a/Templates/lotus.rb
+++ b/Templates/lotus.rb
@@ -8,11 +8,13 @@ class Lotus < Formula
   depends_on "hwloc"
 
   on_macos do
-    url "${NODE_MACOS_URL}"
-    sha256 "${NODE_MACOS_SHA}"
+    on_arm do
+      url "${NODE_MACOS_URL}"
+      sha256 "${NODE_MACOS_SHA}"
 
-    def install
-      bin.install "lotus"
+      def install
+        bin.install "lotus"
+      end
     end
   end
 

--- a/load-from-github.sh
+++ b/load-from-github.sh
@@ -31,14 +31,14 @@ miner_tag=$(get_latest_release "miner/v")
 miner_version=${miner_tag#"miner/v"}
 
 # Node URLS
-node_macos_url="https://github.com/${REPO}/releases/download/${node_tag}/lotus_${node_tag}_darwin_all.tar.gz"
-node_macos_sha_url="https://github.com/${REPO}/releases/download/${node_tag}/lotus_${node_tag}_darwin_all.tar.gz.sha512"
+node_macos_url="https://github.com/${REPO}/releases/download/${node_tag}/lotus_${node_tag}_darwin_arm64.tar.gz"
+node_macos_sha_url="https://github.com/${REPO}/releases/download/${node_tag}/lotus_${node_tag}_darwin_arm64.tar.gz.sha512"
 node_linux_intel_url="https://github.com/${REPO}/releases/download/${node_tag}/lotus_${node_tag}_linux_amd64_v1.tar.gz"
 node_linux_intel_sha_url="https://github.com/${REPO}/releases/download/${node_tag}/lotus_${node_tag}_linux_amd64_v1.tar.gz.sha512"
 
 # Miner URLS
-miner_macos_url="https://github.com/${REPO}/releases/download/${miner_tag}/lotus-miner_v${miner_version}_darwin_all.tar.gz"
-miner_macos_sha_url="https://github.com/${REPO}/releases/download/${miner_tag}/lotus-miner_v${miner_version}_darwin_all.tar.gz.sha512"
+miner_macos_url="https://github.com/${REPO}/releases/download/${miner_tag}/lotus-miner_v${miner_version}_darwin_arm64.tar.gz"
+miner_macos_sha_url="https://github.com/${REPO}/releases/download/${miner_tag}/lotus-miner_v${miner_version}_darwin_arm64.tar.gz.sha512"
 miner_linux_intel_url="https://github.com/${REPO}/releases/download/${miner_tag}/lotus-miner_v${miner_version}_linux_amd64_v1.tar.gz"
 miner_linux_intel_sha_url="https://github.com/${REPO}/releases/download/${miner_tag}/lotus-miner_v${miner_version}_linux_amd64_v1.tar.gz.sha512"
 


### PR DESCRIPTION
## Related Issues

https://github.com/filecoin-project/lotus/issues/13262

Note, we should merge this after https://github.com/filecoin-project/lotus/pull/13273 and after the last release that we want to contain the amd64 binaries.